### PR TITLE
New link for the S4x15 pcap files

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,10 +282,10 @@ Feel free to [contribute](CONTRIBUTING.md).
     </tr>
     <tr>
         <td>
-            <a href="https://www.digitalbond.com/s4/s4x15-week/s4x15-ics-village/" target="_blank">S4x15 ICS Village</a>
+            <a href="https://www.netresec.com/?page=DigitalBond_S4" target="_blank">S4x15 ICS Village</a>
         </td>
         <td>
-            PCAPS from the S4x15 CTF as used during the contest.
+            Mirror for the PCAPS from the S4x15 CTF as used during the contest.
         </td> 
     </tr>
     <tr>


### PR DESCRIPTION
The link is broken for the s4x15 pcap files, this link is current.